### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/sources/setup/workspace_template/desktopRuntime/RTWebViewClient.html
+++ b/sources/setup/workspace_template/desktopRuntime/RTWebViewClient.html
@@ -85,6 +85,20 @@ POSSIBILITY OF SUCH DAMAGE.
 						imgElements[i].src = faviconSrc;
 					}
 				}
+				// Helper to validate URLs before assigning to iframe.src
+				function isSafeURL(url) {
+					try {
+						var parsed = new URL(url, window.location.origin);
+						// Allow only http, https, and about protocols
+						if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "about:") {
+							return true;
+						}
+						return false;
+					} catch (e) {
+						return false;
+					}
+				}
+
 				function setupElementListeners() {
 					elements.button_allow.addEventListener("click", function() {
 						if(websocketInstance !== null) {
@@ -297,7 +311,12 @@ POSSIBILITY OF SUCH DAMAGE.
 					if(webviewOptions.contentMode === "BLOB_BASED") {
 						currentIFrame.srcdoc = webviewOptions.blob;
 					}else {
-						currentIFrame.src = webviewOptions.url;
+						if (isSafeURL(webviewOptions.url)) {
+							currentIFrame.src = webviewOptions.url;
+						} else {
+							setErrored("Blocked potentially unsafe URL: " + webviewOptions.url);
+							return;
+						}
 					}
 					currentIFrame.focus();
 					if(webviewOptions.scriptEnabled && webviewOptions.serverMessageAPIEnabled) {


### PR DESCRIPTION
Potential fix for [https://github.com/eaglercraftex/eaglercraftex/security/code-scanning/2](https://github.com/eaglercraftex/eaglercraftex/security/code-scanning/2)

To fix this vulnerability, we must ensure that only safe, expected URLs are assigned to the iframe's `src` attribute. The best approach is to validate the URL before using it. This can be done by:

- Parsing the URL and ensuring it uses an allowed protocol (e.g., `http:`, `https:`, or possibly `about:blank`).
- Rejecting or sanitizing any URLs with dangerous schemes such as `javascript:`, `data:`, or `vbscript:`.
- If the URL is relative, resolving it against a known safe base.
- If the URL is not valid or not allowed, either refuse to load it or display an error.

The change should be made in the region where `currentIFrame.src = webviewOptions.url;` is set (around line 300). We will add a helper function to validate the URL, and only assign it to the iframe if it passes validation. If not, we can call `setErrored` or take another safe action.

We will also need to add the helper function in the same file, above its first use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
